### PR TITLE
Initial php 8.4 test 1.x

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ ubuntu-latest, windows-latest, macOS-latest ]
-        php-versions: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+        php-versions: [ '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
     name: PHP ${{ matrix.php-versions }} Test on ${{ matrix.operating-system }}
     steps:
       - name: Checkout


### PR DESCRIPTION
# Description

Add the nightly php 8.4 build to the CI tests.

Fixes #5 

## Type of change

* php version support

# How Has This Been Tested?

- CI Tests

# Checklist:

- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
